### PR TITLE
Fix error in Nuxt >3.4

### DIFF
--- a/composables/useWpApi.ts
+++ b/composables/useWpApi.ts
@@ -7,7 +7,7 @@ import { Post } from "~~/types/post";
 
 export default () => {
   const config = useRuntimeConfig();
-  const WP_URL: string = config.wpUri;
+  const WP_URL: string = config.public.wpUri;
 
   const get = async <T>(endpoint: string) => {
     return useFetch<T>(`${WP_URL}/wp-json/wp/v2/${endpoint}`);


### PR DESCRIPTION
Make app work in Nuxt ver. >3.4

I got this error: 
[nuxt] [runtimeConfig] You are trying to access a public runtime config value (apiBase) directly from the top level. This currently works (for backward compatibility with Nuxt 2) but this compatibility layer will be removed in v3.5. Instead, you can update config['apiBase'] to config.public['apiBase'].